### PR TITLE
Added Adblock4limbo.stoverride

### DIFF
--- a/Adblock4limbo.stoverride
+++ b/Adblock4limbo.stoverride
@@ -1,0 +1,284 @@
+name: Adblock4limbo
+desc: 毒奶去网页广告计划（稳定版）For Surge / Quantumult X ；如去内容农场/百度与谷歌搜索结果页面广告/禁漫天堂/低端影视/片库网/Gimy剧迷网/Pornhub/Jable等视频网站广告或其他ACG网站网页广告/百度知道广告。(with some patches applied)
+# Reformatted for Stash
+# Patch: commented 302 to m.baidu.com
+
+http:
+  url-rewrite:
+    # missav 播放页弹窗
+    - https?:\/\/[0-9a-zA-Z]{10,16}\.cloudfront\.net\/\?[a-z]{3,7}=\d{4,8} - reject
+    # Avple 弹窗跳转
+    - ^https?:\/\/assert\.avple\.tv\/file\/avple-images\/ad\.js - reject
+    # www.tvn.cc 韩剧TV
+    #
+    # Pornhub 视频广告
+    - ^https:\/\/(cn|www)\.pornhub\.com\/_xa\/ads.* - reject
+    # javmost 播放页弹窗广告
+    - ^https:\/\/suzihaza\.com\/asset\/jquery\/slim-3\.2\.min\.js.* - reject
+    # 百度网页跳转至手机网页版本
+    #- www.baidu.com(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))) m.baidu.com 302
+    # 禁知乎网页广告
+    - https://(www|zhuanlan)\.zhihu\.com/api/v4/questions/\d+/related-readings - reject
+    - https://(www|zhuanlan)\.zhihu\.com/api/v4/answers/\d+/related-readings - reject
+    #- https://(www|zhuanlan)\.zhihu\.com/api/v4/hot_recommendation - reject
+    - https://(www|zhuanlan)\.zhihu\.com/commercial_api/banners_v3/(mobile_banner|mobile_question) - reject
+    - https://(www|zhuanlan)\.zhihu\.com/api/articles/\d+/recommendation - reject
+    # missav 直播跳出广告
+    - https://creative.live.missav.com/widgets/Spot/lib.js - reject
+  mitm:
+    - "www.ttsp.tv"
+    - "*.cloudfront.net"
+    - "www.o8tv.com"
+    - "www.5dy*"
+    - "*.tvn.cc"
+    - "www.wnacg.com"
+    - "www.wnacg.org"
+    - "suzihaza.com"
+    - "91porn.com"
+    - "netflav.com"
+    - "www.javmost.xyz"
+    - "javmost.xyz"
+    - "www5.javmost.xyz"
+    - "www5.javmost.com"
+    - "www.bing.com"
+    - "zhuanlan.zhihu.com"
+    - "www.zhihu.com"
+    - "jable.tv"
+    - "*.tvn.cc"
+    - "ddrk.me"
+    - "ddys.tv"
+    - "ddys2.me"
+    - "18comic.org"
+    - "18comic.vip"
+    - "www.google.com"
+    - "www.google.com.hk"
+    - "cn.pornhub.com"
+    - "missav.com"
+    - "www.libvio.com"
+    - "4hu.*"
+    - "*.gimy.*"
+    - "*.duboku.*"
+    - "assert.avple.tv"
+    - "avple.tv"
+    - "*.btbdys.*"
+    - "*.javbus.*"
+    - "www.bdys01.com"
+    - "www.baidu.com"
+    - "m.baidu.com"
+    - "zhidao.baidu.com"
+  script:
+    # 知道搜索广告(baidu)
+    - match: ^https?:\/\/(zhidao)\.baidu\.com\/(question|index|\?fr|\?word)
+      name: surge_baidu.zhidao
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 搜索首页广告(baidu)
+    - match: ^https?:\/\/(www|m)\.baidu\.com(/$|\/\?ref.*)(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8)))
+      name: surge_baidu.index
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 搜索结果广告(baidu)
+    - match: ^https?:\/\/(www|m)\.baidu\.com(\/s\?word.*|\/from.*?\/s\?word.*|\/from.*?word=.*)
+      name: surge_baidu
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 内容农场(bing)
+    - match: https?:\/\/(www\.bing)(\.\w{2,4}){1,2}\/(search\?.*|\?sa=|\?FORM)(?!.*?(apps=))
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 内容农场(google)
+    - match: https?:\/\/(www\.google)(\.\w{2,4}){1,2}\/(search\?|\?sa=|\?FORM)(?!.*?(apps=))
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 禁漫天堂(18comic.org|vip)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(18comic)(\.)\w{0,3})(?!.*?(/(cdn-cgi|onclick)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 紳士漫畫(www.wnacg.com)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(wnacg)(\.)\w{0,3})(?!.*?(/(cdn-cgi|onclick)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 剧迷网(gimy.app)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(gimy)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_gimy
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 低端影视(ddrk.me)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(ddys|ddrk|ddys2)(\.)\w{0,3})(?!.*?(\.webmanifest|/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 哔嘀影视播放页(www.btbdys.com)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(btbdys|bdys01)(\.)\w{0,3})\/play\/.*?\.htm.*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 哔嘀影视展示页(www.btbdys.com)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(btbdys|bdys01)(\.)\w{0,3})(?!.*?(/(cdn-cgi|verifyCode|member\/|zzzzz)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8|ddr))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 独播库(www.duboku.tv)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(duboku)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8|ddr))).*
+      name: surge_duboku
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 韩剧TV(www.tvn.cc)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(tvn)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 555电影网(555dy.com)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(5dy5|o8tv)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 梨播(www.libvio.com)
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(libvio)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_libvio
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # netflav.com
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(netflav)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_netflav
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # javmost.xyz
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(javmost)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_javmost
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # www.javbus.com
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(javbus)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_javbus
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # avple.tv
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(avple)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_avple
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # jable.tv
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(jable)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # missav.com
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(missav)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 4hu.tv
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(4hu)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|php|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: surge_4hu
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # cn.pornhub.com
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(pornhub)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # 91porn
+    - match: ^https?:\/\/(\w{0,3}(\.){0,1}(91porn)(\.)\w{0,3})(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|gif|ico|mp3|mp4|svg|tff|ttf|PNG|woff|woff2|m3u8))).*
+      name: surge_91porn
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+    # ttsp
+    - match: ^https?:\/\/(www.ttsp.tv)(?!.*?(/(cdn-cgi)))(?!.*?(\.(css|js|jpeg|jpg|png|gif|ico|mp3|mp4|svg|tff|PNG|woff|woff2|m3u8))).*
+      name: Adblock4limbo
+      type: response
+      require-body: true
+      timeout: 5
+      argument: ""
+script-providers:
+  surge_baidu.zhidao:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_baidu.zhidao.js
+    interval: 172800
+  surge_baidu.index:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_baidu.index.js
+    interval: 172800
+  surge_baidu:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_baidu.js
+    interval: 172800
+  Adblock4limbo:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/Adblock4limbo.js
+    interval: 172800
+  surge_gimy:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_gimy.js
+    interval: 172800
+  surge_duboku:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_duboku.js
+    interval: 172800
+  surge_libvio:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_libvio.js
+    interval: 172800
+  surge_netflav:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_netflav.js
+    interval: 172800
+  surge_javmost:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_javmost.js
+    interval: 172800
+  surge_javbus:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_javbus.js
+    interval: 172800
+  surge_avple:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_avple.js
+    interval: 172800
+  surge_4hu:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_4hu.js
+    interval: 172800
+  surge_91porn:
+    url: https://raw.githubusercontent.com/limbopro/Adblock4limbo/main/Adguard/surge_91porn.js
+    interval: 172800


### PR DESCRIPTION
基于Adblock4limbo.sgmodule重写而来的Adblock4limbo Stash版。
写这个主要原因是surge在mac上的性能表现太差。
参考Adblock4limbo.conf发现没有m.baidu.com的302跳转，个人角度（页面美观偏好）考虑先注释掉了那条规则，不是很确定那条规则的必要性在哪。